### PR TITLE
Add a fetch-crl equivalent

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -6,7 +6,9 @@ IFS=$'\n\t'
 ls "${PKG_NAME}"
 mkdir -p "${PREFIX}/etc/grid-security/certificates"
 cp -r  "${PKG_NAME}"/* "${PREFIX}/etc/grid-security/certificates"
+cp "${RECIPE_DIR}/refresh_crls.sh" "${PREFIX}/etc/grid-security/certificates"
 chmod -R 755 "${PREFIX}/etc/grid-security/certificates"
+"${PREFIX}/etc/grid-security/certificates/refresh_crls.sh"
 
 # Actiation scripts
 mkdir -p "${PREFIX}/etc/conda/activate.d"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -248,7 +248,7 @@ source:
 
 build:
   noarch: generic
-  number: 0
+  number: 1
   # DIRAC will try to update these automatically so avoid linking between environments
   no_link:
     - ${PREFIX}/etc/grid-security/certificates/*

--- a/recipe/refresh_crls.sh
+++ b/recipe/refresh_crls.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+IFS=$'\n\t'
+
+SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+
+for crl_url_file in "${SCRIPT_DIR}"/*.crl_url
+do
+    pem=${crl_url_file//crl_url/pem}
+    echo "${pem}";
+    for subject_hash in $(openssl x509 -in "${pem}" -noout -subject_hash -subject_hash_old);
+    do
+        echo "${subject_hash}";
+        echo "${crl_url_file}";
+        curl -L --max-time 10 "$(cat "${crl_url_file}")" | openssl crl > "${SCRIPT_DIR}/${subject_hash}.r0" ;
+    done
+done


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
This adds a script to fetch the CRLs like fetch-crl does
-->
